### PR TITLE
Use overflow: auto instead of overflow: scroll

### DIFF
--- a/app/style/index.scss
+++ b/app/style/index.scss
@@ -31,7 +31,7 @@ body {
   height: 100%;
   overflow: hidden;
   &:hover {
-    overflow: scroll;
+    overflow: auto;
     overflow: overlay;
   }
 }

--- a/dist/app.css
+++ b/dist/app.css
@@ -72,7 +72,7 @@ body {
   overflow: hidden;
 }
 .root-container:hover {
-  overflow: scroll;
+  overflow: auto;
   overflow: overlay;
 }
 


### PR DESCRIPTION
This is for non-webkit browser.
"scroll" means always show the scrollbar, even when not needed. "auto" will only show when it is needed.

Right now, the scrollbar can be very distracting on Firefox.